### PR TITLE
Add envvar URFKILL_NO_SYSLOG

### DIFF
--- a/src/urf-main.c
+++ b/src/urf-main.c
@@ -176,10 +176,12 @@ main (gint argc, gchar **argv)
 	if (debug)
 		log_level |= G_LOG_LEVEL_DEBUG;
 
-	g_log_set_handler (G_LOG_DOMAIN,
-	                   log_level | G_LOG_FLAG_FATAL | G_LOG_FLAG_RECURSION,
-	                   (GLogFunc) urf_log_handler,
-	                   NULL);
+	if (getenv("URFKILL_NO_SYSLOG") == 0) {
+		g_log_set_handler (G_LOG_DOMAIN,
+				   log_level | G_LOG_FLAG_FATAL | G_LOG_FLAG_RECURSION,
+				   (GLogFunc) urf_log_handler,
+				   NULL);
+	}
 
 	if (conf_file == NULL)
 		conf_file = URFKILL_CONFIG_FILE;


### PR DESCRIPTION
Add envvar URFKILL_NO_SYSLOG which allows log and debug messages to be printed to stdout.

This will make it easier to debug urfkill for example by doing:

$ sudo URFKILL_NO_SYSLOG=1 G_MESSAGES=all src/urfkilld
