### PR TITLE
"Strict" Flight Mode

### DIFF
--- a/src/urf-arbitrator.c
+++ b/src/urf-arbitrator.c
@@ -167,13 +167,15 @@ urf_arbitrator_set_flight_mode (UrfArbitrator  *arbitrator,
 
 	for (i = RFKILL_TYPE_ALL + 1; i < NUM_RFKILL_TYPES; i++) {
 
-		/* Handle modem separately: we shouldn't save states here,
-		 * because there is no UI switch for just modem.
-		 */
-		if (i == RFKILL_TYPE_WWAN) {
-			ret = urf_arbitrator_set_block (arbitrator, i, block);
-			urf_config_set_persist_state(priv->config, i, block);
-			continue;
+		if (urf_config_get_strict_flight_mode (priv->config)) {
+			/* Handle modem separately: we shouldn't save states here,
+			 * because there is no UI switch for just modem.
+			 */
+			if (i == RFKILL_TYPE_WWAN) {
+				ret = urf_arbitrator_set_block (arbitrator, i, block);
+				urf_config_set_persist_state(priv->config, i, block);
+				continue;
+			}
 		}
 
 		state = urf_killswitch_get_state (priv->killswitch[i]);

--- a/src/urf-config.h
+++ b/src/urf-config.h
@@ -62,6 +62,7 @@ gboolean	 urf_config_get_key_control	(UrfConfig	*config);
 gboolean	 urf_config_get_master_key	(UrfConfig	*config);
 gboolean	 urf_config_get_force_sync	(UrfConfig	*config);
 gboolean	 urf_config_get_persist		(UrfConfig	*config);
+gboolean	 urf_config_get_strict_flight_mode	(UrfConfig	*config);
 
 gboolean	 urf_config_get_persist_state	(UrfConfig	*config,
 						 const gint type);


### PR DESCRIPTION
Add a configuration file option (defaults to enabled) to use "strict" flight mode.

The concept is that only Flight Mode should change WWAN state, and WWAN state needs to follow flight mode state.

It's not convenient/possible to improve this by returning errors when a call is made to set a WWAN device blocked since these calls can also happen when a WWAN type rfkill switch is triggered in the kernel. Similarly, flight mode itself uses the same calls.

It should be up to UI to not expose or use the explicitly WWAN device toggle, and only show flight mode.
