### PR TITLE
UrfDeviceOfono: fix improper usage of GError

### DIFF
--- a/src/urf-device-ofono.c
+++ b/src/urf-device-ofono.c
@@ -188,7 +188,7 @@ set_online_cb (GObject *source_object,
 	UrfDeviceOfono *modem = URF_DEVICE_OFONO (user_data);
 	UrfDeviceOfonoPrivate *priv = URF_DEVICE_OFONO_GET_PRIVATE (modem);
 	GVariant *result;
-	GError *error;
+	GError *error = NULL;
 	gint code = 0;
 
 	result = g_dbus_proxy_call_finish (priv->proxy, res, &error);


### PR DESCRIPTION
Fix improper usage of GError, by ensuring that
*error is initialized to NULL before using it in
g_dbus_proxy_call_finish().
