### PR TITLE
UrfDaemon: fix BlockIdx and Block DBus logic

### DIFF
--- a/src/urf-daemon.c
+++ b/src/urf-daemon.c
@@ -356,7 +356,7 @@ out:
 
 	} else if (done) {
 
-		g_dbus_method_invocation_return_value (priv->invocation,
+		g_dbus_method_invocation_return_value (invocation,
 						       g_variant_new ("(b)", TRUE));
 	}
 }
@@ -476,6 +476,9 @@ urf_daemon_block_idx (UrfDaemon             *daemon,
 		goto out;
 	}
 
+	priv->pending_block = block;
+	priv->invocation = invocation;
+
 	task = g_task_new (daemon, NULL, block_idx_cb, NULL);
 	g_task_set_task_data (task, GINT_TO_POINTER (index), NULL);
 
@@ -494,7 +497,7 @@ out:
 
 	} else if (done) {
 
-		g_dbus_method_invocation_return_value (priv->invocation,
+		g_dbus_method_invocation_return_value (invocation,
 						       g_variant_new ("(b)", TRUE));
 	}
 


### PR DESCRIPTION
Both methods incorrectly used priv->invocation when
calling dbus_method_invocation_return_value, when
the parameter invocation should've been used instead.
Also BlockIdx failed to set priv->invocation and
priv->block.  These problems caused urfkill to fail
when generating DBus method returns, causing a timeout
to occur at the caller, even though the underlying
operation succeeded.
