### PR TITLE
Handle ofono restart

### DIFF
--- a/src/urf-device-ofono.c
+++ b/src/urf-device-ofono.c
@@ -419,6 +419,11 @@ dispose (GObject *object)
 {
 	UrfDeviceOfonoPrivate *priv = URF_DEVICE_OFONO_GET_PRIVATE (object);
 
+	if (priv->proxy) {
+		g_object_unref (priv->proxy);
+		priv->proxy = NULL;
+	}
+
 	if (priv->modem_path) {
 		g_free (priv->modem_path);
 		priv->modem_path = NULL;


### PR DESCRIPTION
 Urfkill was crashing when ofono re-started because resources where not properly released when a ModemRemoved signal was received. Also, the id counter was not being reset and urf_device_ofono_get_modem_path was being called with a wrong argument.

The PR fixes

https://bugs.launchpad.net/ubuntu/+source/urfkill/+bug/1346685
