### PR TITLE
UrfOfonoManager: check NULL proxy (LP: #1381818)

### DIFF
--- a/src/urf-ofono-manager.c
+++ b/src/urf-ofono-manager.c
@@ -162,6 +162,9 @@ ofono_get_modems_cb (GObject *source_object,
 	gchar *modem_path;
 	GError *error = NULL;
 
+	if (ofono->proxy == NULL)
+		return;
+
 	value = g_dbus_proxy_call_finish (ofono->proxy, res, &error);
 
 	if (!error) {


### PR DESCRIPTION
If ofono disappears from the bus, ofono->proxy is
unref'd and set to NULL.  This change adds a check
in get_modems_cb() to prevent a crash caused by
passing this NULL proxy to g_dbus_proxy_call_finish().
