### PR TITLE
Avoid double call to set ofono's online property

### DIFF
--- a/src/urf-device-ofono.h
+++ b/src/urf-device-ofono.h
@@ -47,6 +47,9 @@ typedef struct {
 
 typedef struct {
         UrfDeviceClass parent;
+
+        void 		(*device_powered)	(UrfDeviceOfono	*device,
+						 gboolean powered);
 } UrfDeviceOfonoClass;
 
 


### PR DESCRIPTION
On initialization a double call to set-soft was being done for the ofono device. This caused bugs LP #1392397 and #1379807.
